### PR TITLE
LFH-66 small changes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
       "semi": ["warn", "always"],
       "quotes": ["warn", "double"],
       "no-trailing-spaces": "warn",
+      "comma-dangle": "warn",
       "max-len": [1, 120],
       "no-case-declarations": "warn",
       "no-console": "warn",

--- a/src/Categories/index.js
+++ b/src/Categories/index.js
@@ -1,8 +1,6 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
-import { useQuery } from "@apollo/react-hooks";
 import { List, ListItem, ListItemText, Typography } from "@material-ui/core";
-import { GET_CATEGORIES_QUERY } from "./queries";
 import startCase from "lodash/startCase";
 import { makeStyles } from "@material-ui/core/styles";
 import purple from "@material-ui/core/colors/purple";
@@ -10,7 +8,9 @@ import purple from "@material-ui/core/colors/purple";
 const useStyles = makeStyles((theme) => ({
   heading: {
     paddingLeft: theme.spacing(2),
-    marginTop: theme.spacing(2)
+    marginTop: theme.spacing(2),
+    fontFamily: "ChronicleDisp-Roman",
+    fontWeight: "bold"
   },
   selected: {
     color: purple[500],
@@ -18,13 +18,9 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-export const Categories = ({ handleFilterChange }) => {
+export const Categories = ({ handleFilterChange, categoryList }) => {
   const classes = useStyles();
   const [categoryTitle, setCategoryTitle] = useState(null);
-  const { loading, error, data } = useQuery(GET_CATEGORIES_QUERY);
-
-  if (error) return <p>Error</p>;
-  if (loading) return <p>Loading...</p>;
 
   function handleCategorySelection(e) {
     const value = e.currentTarget.getAttribute("value");
@@ -34,7 +30,7 @@ export const Categories = ({ handleFilterChange }) => {
 
   return(
     <div>
-      <Typography variant="h6" className={classes.heading}>
+      <Typography variant="h4" className={classes.heading}>
         Categories
       </Typography>
       <List>
@@ -44,7 +40,7 @@ export const Categories = ({ handleFilterChange }) => {
             classes={{ primary: categoryTitle === null ? classes.selected : "" }}
           />
         </ListItem>
-        {data.categories.map((category) => (
+        {categoryList.map((category) => (
           <ListItem button key={category.id} onClick={handleCategorySelection} value={category.title}>
             <ListItemText
               primary={startCase(category.title)}
@@ -58,5 +54,6 @@ export const Categories = ({ handleFilterChange }) => {
 };
 
 Categories.propTypes = {
-  handleFilterChange: PropTypes.func
+  handleFilterChange: PropTypes.func,
+  categoryList: PropTypes.array
 };

--- a/src/Crafts/index.js
+++ b/src/Crafts/index.js
@@ -1,7 +1,5 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
-import { useQuery } from "@apollo/react-hooks";
-import { GET_CRAFTS_QUERY } from "./queries";
 import startCase from "lodash/startCase";
 import { FormGroup, FormControl, FormControlLabel, Checkbox, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
@@ -12,17 +10,15 @@ const useStyles = makeStyles((theme) => ({
   },
   heading: {
     paddingLeft: theme.spacing(2),
-    marginTop: theme.spacing(2)
-  },
+    marginTop: theme.spacing(2),
+    fontFamily: "ChronicleDisp-Roman",
+    fontWeight: "bold"
+  }
 }));
 
-export const Crafts = ({ handleFilterChange }) => {
+export const Crafts = ({ handleFilterChange, craftList }) => {
   const classes = useStyles();
   const [craftTitles, setCraftTitles] = useState([]);
-  const { loading, error, data } = useQuery(GET_CRAFTS_QUERY);
-
-  if (loading) return <p>Loading...</p>;
-  if (error) return <p>Error</p>;
 
   function handleCraftsSelection(e) {
     e.persist();
@@ -40,11 +36,11 @@ export const Crafts = ({ handleFilterChange }) => {
 
   return(
     <FormControl component="fieldset">
-      <Typography variant="h6" className={classes.heading}>
+      <Typography variant="h4" className={classes.heading}>
         <legend>Crafts</legend>
       </Typography>
         <FormGroup className={classes.formGroup}>
-          {data.crafts.map((craft) => (
+          {craftList.map((craft) => (
             <FormControlLabel
               key={craft.id}
               control={<Checkbox
@@ -62,5 +58,6 @@ export const Crafts = ({ handleFilterChange }) => {
 };
 
 Crafts.propTypes = {
-  handleFilterChange: PropTypes.func
+  handleFilterChange: PropTypes.func,
+  craftList: PropTypes.array
 };

--- a/src/Grades/data.js
+++ b/src/Grades/data.js
@@ -1,0 +1,1 @@
+export const DEFAULT_GRADE = "analystDeveloper";

--- a/src/Grades/index.js
+++ b/src/Grades/index.js
@@ -1,16 +1,17 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
-import { useQuery } from "@apollo/react-hooks";
-import { GET_GRADES_QUERY } from "./queries";
 import { List, ListItem, ListItemText, Typography } from "@material-ui/core";
 import startCase from "lodash/startCase";
 import { makeStyles } from "@material-ui/core/styles";
 import teal from "@material-ui/core/colors/teal";
+import { DEFAULT_GRADE } from "./data";
 
 const useStyles = makeStyles((theme) => ({
   heading: {
     paddingLeft: theme.spacing(2),
-    marginTop: theme.spacing(2)
+    marginTop: theme.spacing(2),
+    fontFamily: "ChronicleDisp-Roman",
+    fontWeight: "bold"
   },
   selected: {
     color: teal[500],
@@ -18,13 +19,9 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-export const Grades = ({ handleFilterChange }) => {
+export const Grades = ({ handleFilterChange, gradeList }) => {
   const classes = useStyles();
-  const [gradeTitle, setGradeIdTitle] = useState(null);
-  const { loading, error, data } = useQuery(GET_GRADES_QUERY);
-
-  if (error) return <p>Error</p>;
-  if (loading) return <p>Loading...</p>;
+  const [gradeTitle, setGradeIdTitle] = useState(DEFAULT_GRADE);
 
   function handleGradeSelection(e) {
     const value = e.currentTarget.getAttribute("value");
@@ -34,11 +31,11 @@ export const Grades = ({ handleFilterChange }) => {
 
   return(
     <div>
-      <Typography variant="h6" className={classes.heading}>
+      <Typography variant="h4" className={classes.heading}>
         Grade
       </Typography>
       <List>
-        {data.grades.map((grade) => (
+        {gradeList.map((grade) => (
           <ListItem button key={grade.id} onClick={handleGradeSelection} value={grade.title}>
             <ListItemText
               primary={startCase(grade.title)}
@@ -52,5 +49,6 @@ export const Grades = ({ handleFilterChange }) => {
 };
 
 Grades.propTypes = {
-  handleFilterChange: PropTypes.func
+  handleFilterChange: PropTypes.func,
+  gradeList: PropTypes.array
 };

--- a/src/Grades/queries.js
+++ b/src/Grades/queries.js
@@ -5,6 +5,7 @@ export const GET_GRADES_QUERY = gql`
     grades {
       id
       title
+      description
     }
   }
 `;

--- a/src/Home/index.js
+++ b/src/Home/index.js
@@ -1,16 +1,24 @@
 import React, { useState } from "react";
-import { Drawer, Divider, Typography, AppBar, Toolbar, } from "@material-ui/core";
+import { useQuery } from "@apollo/react-hooks";
+import startCase from "lodash/startCase";
+
+import { Drawer, Divider, Typography, AppBar, Toolbar } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
+
 import { Grades } from "../Grades";
+import { GET_GRADES_QUERY } from "../Grades/queries";
+import { DEFAULT_GRADE } from "../Grades/data";
 import { Categories } from "../Categories";
+import { GET_CATEGORIES_QUERY } from "../Categories/queries";
 import { Crafts } from "../Crafts";
+import { GET_CRAFTS_QUERY } from "../Crafts/queries";
 import { Skills } from "../Skills";
 
 const drawerWidth = 300;
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    display: "flex",
+    display: "flex"
   },
   appBar: {
     backgroundColor: "#323232",
@@ -21,23 +29,53 @@ const useStyles = makeStyles((theme) => ({
     flexShrink: 0
   },
   drawerPaper: {
-    width: drawerWidth,
+    width: drawerWidth
   },
   content: {
     flexGrow: 1,
-    padding: theme.spacing(3),
+    padding: theme.spacing(3)
   },
+  heading: {
+    fontFamily: "ChronicleDisp-Roman"
+  }
 }));
 
 const Home = () => {
   const classes = useStyles();
-  const [queryFilter, setQueryFilter] = useState({});
+  const [queryFilter, setQueryFilter] = useState({gradeTitle: DEFAULT_GRADE});
+
+  const {
+    loading: gradesLoading,
+    error: gradesError,
+    data: gradesResponse
+  } = useQuery(GET_GRADES_QUERY);
+
+  const {
+    loading: categoriesLoading,
+    error: categoriesError,
+    data: categoriesResponse
+  } = useQuery(GET_CATEGORIES_QUERY);
+
+  const {
+    loading: craftsLoading,
+    error: craftsError,
+    data: craftsResponse
+  } = useQuery(GET_CRAFTS_QUERY);
+
+  const selectedGradeTitle = queryFilter.gradeTitle;
+
+  function getSelectedGradeByTitle(title) {
+    return gradesResponse.grades.find((grade) => grade.title === title);
+  }
 
   function handleFilterChange(value) {
     setQueryFilter(oldDetails => {
       return { ...oldDetails, ...value };
      });
   }
+
+  if (gradesLoading || categoriesLoading || craftsLoading) return <p>Loading...</p>;
+  if (gradesError || categoriesError || craftsError) return <p>Error</p>;
 
   return(
     <div className={classes.root}>
@@ -52,23 +90,35 @@ const Home = () => {
           className={classes.drawer}
           variant="permanent"
           classes={{
-            paper: classes.drawerPaper,
+            paper: classes.drawerPaper
           }}
         >
           <Toolbar />
           <div>
-            <Grades handleFilterChange={handleFilterChange} />
+            <Grades
+              handleFilterChange={handleFilterChange}
+              gradeList={gradesResponse.grades}
+            />
             <Divider />
-            <Categories handleFilterChange={handleFilterChange} />
+            <Categories
+              handleFilterChange={handleFilterChange}
+              categoryList={categoriesResponse.categories}
+            />
             <Divider />
-            <Crafts handleFilterChange={handleFilterChange} />
+            <Crafts
+              handleFilterChange={handleFilterChange}
+              craftList={craftsResponse.crafts}
+            />
           </div>
         </Drawer>
       <main className={classes.content}>
         <Toolbar />
         <Typography variant="h1" className={classes.heading}>
-            Skills
-          </Typography>
+          { startCase(selectedGradeTitle) }
+        </Typography>
+        <Typography variant="body2">
+          { getSelectedGradeByTitle(selectedGradeTitle).description }
+        </Typography>
         <Skills queryDetails={ { variables: { filter: queryFilter } } } />
       </main>
     </div>

--- a/src/Skills/index.js
+++ b/src/Skills/index.js
@@ -5,24 +5,15 @@ import { GET_SKILLS_QUERY } from "./queries";
 import { groupSkillsByTitle } from "../utils/formatters";
 import { List, ListItem, ListItemText, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
-import { teal, purple } from "@material-ui/core/colors";
 import startCase from "lodash/startCase";
+import isEmpty from "lodash/isEmpty";
 
 const useStyles = makeStyles((theme) => ({
-  listItem: {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "flex-start"
+  container: {
+    marginTop: theme.spacing(4)
   },
-  gradeChip: {
-    color: "white",
-    backgroundColor: teal[500],
-    margin: theme.spacing(0.5)
-  },
-  categoryChip: {
-    color: "white",
-    backgroundColor: purple[500],
-    margin: theme.spacing(0.5)
+  topicContainer: {
+    marginBottom: theme.spacing(4)
   }
 }));
 
@@ -41,39 +32,31 @@ export const Skills = ({ queryDetails }) => {
 
   const groupedSkills = groupSkillsByTitle(data["skills"]);
 
-  return(
+  const skills = <div className={classes.container}>
+  {Object.keys(groupedSkills).map((title, index) => {
+    return <div key={index} className={classes.topicContainer}>
+      <Typography
+      component="h5"
+      variant="h5"
+    >
+      {startCase(title)}
+      </Typography>
     <List>
-      {Object.keys(groupedSkills).map((title, index) => {
-        return <ListItem key={index} className={classes.listItem}>
-          <ListItemText
-            primary={
-              <React.Fragment>
-                <Typography
-                  component="h6"
-                  variant="h6"
-                  color="textPrimary"
-                >
-                  {startCase(title)}
-                </Typography>
-              </React.Fragment>
-            }
-            secondary={
-              groupedSkills[title].map((skill) => {
-                return <React.Fragment key={skill.id}>
-                <Typography
-                  component="p"
-                  color="textSecondary"
-                >
-                  {skill.description}
-                </Typography>
-              </React.Fragment>;
-              })
-            }
-          />
+      {groupedSkills[title].map((skill) => {
+        return <ListItem key={skill.id}>
+          <ListItemText primary={skill.description} />
         </ListItem>;
       })}
     </List>
-  );
+    </div>;
+  })}
+</div>;
+
+  const noResults = <Typography component="p" variant="body-2" className={classes.container}>
+      No results found. Try changing your filters.
+    </Typography>;
+
+  return(isEmpty(groupedSkills) ? noResults : skills);
 };
 
 Skills.propTypes = {


### PR DESCRIPTION
Small changes including:
- Grade description to show below 'skills" heading
- "Skills" heading to change to be grade title ( to achieve this I had to move the queries to the parent home page and pass the results down as props)
- Analyst developer is default grade
- Filter headings to be more prominent
- Spacing between skills - bullets?
- No results found error state
- Update fonts

![Screenshot 2021-01-11 at 12 48 17 pm](https://user-images.githubusercontent.com/40401118/104184533-7dfc6b00-540b-11eb-9a37-2fc401cf9b9f.png)
![Screenshot 2021-01-11 at 12 48 24 pm](https://user-images.githubusercontent.com/40401118/104184539-7fc62e80-540b-11eb-9b5d-c2655640857d.png)
