### PR TITLE
LFH-101 Remove topic from skill query

### DIFF
--- a/src/Skills/queries.js
+++ b/src/Skills/queries.js
@@ -4,7 +4,6 @@ export const GET_SKILLS_QUERY = gql`
   query Skills($filter: SkillFilter) {
     skills(filter: $filter) {
       id
-      topic
       description
       category {
         id


### PR DESCRIPTION
@Caitlin-cooling have removed topic and examples from the back end and done some work on the categories. 

just putting this little change in so the master front end still vaguely works (accordian headings which use topic now show "undefined" but rest works). 

happy if you want to ignore this PR and address on your refactor ticket. hopefully we can get the back end changes in today so you can rebuild the latest version. 